### PR TITLE
Add code to make extended Table 1 for supplement

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -161,6 +161,16 @@ table1 <- function(cohort){
         table1 = glue("output/table1_{cohort}.csv"),
         table1_rounded = glue("output/table1_{cohort}_rounded.csv")
       )
+    ),
+    action(
+      name = glue("extendedtable1_{cohort}"),
+      run = "r:latest analysis/extendedtable1.R",
+      arguments = c(cohort),
+      needs = list(glue("stage1_data_cleaning_{cohort}")),
+      moderately_sensitive = list(
+        extendedtable1 = glue("output/extendedtable1_{cohort}.csv"),
+        extendedtable1_rounded = glue("output/extendedtable1_{cohort}_rounded.csv")
+      )
     )
   )
 }
@@ -409,6 +419,17 @@ actions_list <- splice(
                  "table1_unvax_extf"),
     moderately_sensitive = list(
       table1_output_rounded = glue("output/table1_output_rounded.csv")
+    )
+  ),
+  
+  action(
+    name = "make_extendedtable1_output",
+    run = "r:latest analysis/make_other_output.R extendedtable1 prevax_extf;vax;unvax_extf",
+    needs = list("extendedtable1_prevax_extf",
+                 "extendedtable1_vax",
+                 "extendedtable1_unvax_extf"),
+    moderately_sensitive = list(
+      table1_output_rounded = glue("output/extendedtable1_output_rounded.csv")
     )
   ),
   

--- a/analysis/extendedtable1.R
+++ b/analysis/extendedtable1.R
@@ -1,0 +1,113 @@
+# Load libraries ---------------------------------------------------------------
+print('Load libraries')
+
+library(magrittr)
+
+# Specify redaction threshold --------------------------------------------------
+print('Specify redaction threshold')
+
+threshold <- 6
+
+# Source common functions ------------------------------------------------------
+print('Source common functions')
+
+source("analysis/utility.R")
+
+# Specify arguments ------------------------------------------------------------
+print('Specify arguments')
+
+args <- commandArgs(trailingOnly=TRUE)
+
+if(length(args)==0){
+  cohort <- "vax"
+} else {
+  cohort <- args[[1]]
+}
+
+
+# Load data --------------------------------------------------------------------
+print("Load data")
+
+df <- readr::read_rds(paste0("output/input_",cohort,"_stage1.rds"))
+
+# Remove people with history of COVID-19 ---------------------------------------
+print("Remove people with history of COVID-19")
+
+df <- df[df$sub_bin_covid19_confirmed_history==FALSE,]
+
+# Create exposure indicator ----------------------------------------------------
+print("Create exposure indicator")
+
+df$exposed <- !is.na(df$exp_date_covid19_confirmed)
+
+# Define consultation rate groups ----------------------------------------------
+print("Define consultation rate groups")
+
+df$cov_cat_consulation_rate <- ""
+df$cov_cat_consulation_rate <- ifelse(df$cov_num_consulation_rate==0, "0", df$cov_cat_consulation_rate)
+df$cov_cat_consulation_rate <- ifelse(df$cov_num_consulation_rate>=1 & df$cov_num_consulation_rate<=5, "1-5", df$cov_cat_consulation_rate)
+df$cov_cat_consulation_rate <- ifelse(df$cov_num_consulation_rate>=6, "6+", df$cov_cat_consulation_rate)
+
+# Filter data ------------------------------------------------------------------
+print("Filter data")
+
+vars <- setdiff(c(colnames(df)[grepl("cov_cat_",colnames(df))], 
+                  colnames(df)[grepl("cov_bin_",colnames(df))]),
+                c("cov_cat_sex",
+                  "cov_cat_ethnicity",
+                  "cov_cat_deprivation",
+                  "cov_cat_smoking_status",
+                  "cov_cat_region",
+                  "cov_bin_carehome_status"))
+
+df <- df[,c("patient_id", "exposed", vars)]
+
+df$All <- "All"
+
+# Aggregate data ---------------------------------------------------------------
+print("Aggregate data")
+
+df <- tidyr::pivot_longer(df,
+                          cols = setdiff(colnames(df),c("patient_id","exposed")),
+                          names_to = "characteristic",
+                          values_to = "subcharacteristic")
+
+df$total <- 1
+
+df <- aggregate(cbind(total, exposed) ~ characteristic + subcharacteristic, 
+                data = df,
+                sum)
+
+df <- df[df$subcharacteristic!=FALSE,]
+df$subcharacteristic <- ifelse(df$subcharacteristic=="","Missing",df$subcharacteristic)
+
+
+# Sort data --------------------------------------------------------------------
+print("Sort data")
+
+df <- df[order(df$subcharacteristic, decreasing = TRUE),]
+df <- df[order(df$characteristic),]
+
+# Save Table 1 -----------------------------------------------------------------
+print('Save Table 1')
+
+write.csv(df, paste0("output/extendedtable1_",cohort,".csv"), row.names = FALSE)
+
+# Perform redaction ------------------------------------------------------------
+print('Perform redaction')
+
+df[,setdiff(colnames(df),c("characteristic","subcharacteristic"))] <- lapply(df[,setdiff(colnames(df),c("characteristic","subcharacteristic"))],
+                                                                             FUN=function(y){roundmid_any(as.numeric(y), to=threshold)})
+
+# Calculate column percentages -------------------------------------------------
+
+df$Npercent <- paste0(df$total,ifelse(df$characteristic=="All","",
+                                      paste0(" (",round(100*(df$total / df[df$characteristic=="All","total"]),1),"%)")))
+
+df <- df[,c("characteristic","subcharacteristic","Npercent","exposed")]
+colnames(df) <- c("Characteristic","Subcharacteristic","N (%)","COVID-19 diagnoses")
+
+# Save Table 1 -----------------------------------------------------------------
+print('Save rounded Table 1')
+
+write.csv(df, paste0("output/extendedtable1_",cohort,"_rounded.csv"), row.names = FALSE)

--- a/project.yaml
+++ b/project.yaml
@@ -177,6 +177,15 @@ actions:
         table1: output/table1_prevax_extf.csv
         table1_rounded: output/table1_prevax_extf_rounded.csv
 
+  extendedtable1_prevax_extf:
+    run: r:latest analysis/extendedtable1.R prevax_extf
+    needs:
+    - stage1_data_cleaning_prevax_extf
+    outputs:
+      moderately_sensitive:
+        extendedtable1: output/extendedtable1_prevax_extf.csv
+        extendedtable1_rounded: output/extendedtable1_prevax_extf_rounded.csv
+
   ## Table 1 - unvax_extf 
 
   table1_unvax_extf:
@@ -188,6 +197,15 @@ actions:
         table1: output/table1_unvax_extf.csv
         table1_rounded: output/table1_unvax_extf_rounded.csv
 
+  extendedtable1_unvax_extf:
+    run: r:latest analysis/extendedtable1.R unvax_extf
+    needs:
+    - stage1_data_cleaning_unvax_extf
+    outputs:
+      moderately_sensitive:
+        extendedtable1: output/extendedtable1_unvax_extf.csv
+        extendedtable1_rounded: output/extendedtable1_unvax_extf_rounded.csv
+
   ## Table 1 - vax 
 
   table1_vax:
@@ -198,6 +216,15 @@ actions:
       moderately_sensitive:
         table1: output/table1_vax.csv
         table1_rounded: output/table1_vax_rounded.csv
+
+  extendedtable1_vax:
+    run: r:latest analysis/extendedtable1.R vax
+    needs:
+    - stage1_data_cleaning_vax
+    outputs:
+      moderately_sensitive:
+        extendedtable1: output/extendedtable1_vax.csv
+        extendedtable1_rounded: output/extendedtable1_vax_rounded.csv
 
   ## Run models 
 
@@ -5237,6 +5264,16 @@ actions:
     outputs:
       moderately_sensitive:
         table1_output_rounded: output/table1_output_rounded.csv
+
+  make_extendedtable1_output:
+    run: r:latest analysis/make_other_output.R extendedtable1 prevax_extf;vax;unvax_extf
+    needs:
+    - extendedtable1_prevax_extf
+    - extendedtable1_vax
+    - extendedtable1_unvax_extf
+    outputs:
+      moderately_sensitive:
+        table1_output_rounded: output/extendedtable1_output_rounded.csv
 
   make_table2_output:
     run: r:latest analysis/make_other_output.R table2 prevax_extf;vax;unvax_extf


### PR DESCRIPTION
This PR adds code to make an extended Table 1 that contains medical history information for individuals in each cohort. This will be used to produce something equivalent to Supplementary Table 4 in post-covid-diabetes manuscript.